### PR TITLE
fix lint errors

### DIFF
--- a/test_data/common.js
+++ b/test_data/common.js
@@ -214,7 +214,7 @@ function scanMakeDataPaths (options, PWD, oldVersion, newVersion, wantFunctions,
     }).map(function (x) {
       return fs.join(fs.join(PWD, 'makedata_suites'), x);
     }).sort();
-  var executed_suites = [];
+  let executed_suites = [];
   suites.forEach(suitePath => {
     let column = [];
     let supported = "";
@@ -247,8 +247,8 @@ function scanMakeDataPaths (options, PWD, oldVersion, newVersion, wantFunctions,
     column.push(suite_filename);
     resultTable.addRow(column);
   });
-  if(excludePreviouslyExecuted){
-    executed_suites.forEach(suite=> {previously_executed_suites.push(suite)});
+  if (excludePreviouslyExecuted) {
+    executed_suites.forEach(suite => { previously_executed_suites.push(suite); });
     fs.write(EXECUTED_TEST_SUITES_FILE, JSON.stringify(previously_executed_suites));
   }
   print(resultTable.toString());


### PR DESCRIPTION
### Scope & Purpose

Fix obvious eslint errors:
```
3rdParty/rta-makedata/test_data/common.js
  251:29  error  Missing space before =>  arrow-spacing
  251:76  error  Missing semicolon        semi
```

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] sidelining PRs
  - [ ] [ArangoDB Pullrequest](https://github.com/arangodb/arangodb/pull/)
  - [ ] [RTA Pullrequest](https://github.com/arangodb/release-test-automation/pull)
