### PR TITLE
fix read only handling

### DIFF
--- a/test_data/checkdata.js
+++ b/test_data/checkdata.js
@@ -68,7 +68,7 @@ const optionsDefaults = {
   disabledDbserverUUID: "",
   minReplicationFactor: 1,
   maxReplicationFactor: 2,
-  readonly: false,
+  readOnly: false,
   bigDoc: false,
   numberOfDBs: 1,
   countOffset: 0,

--- a/test_data/cleardata.js
+++ b/test_data/cleardata.js
@@ -65,6 +65,7 @@ const optionsDefaults = {
   curVersion: dbVersion,
   minReplicationFactor: 1,
   maxReplicationFactor: 2,
+  readOnly: false,
   numberOfDBs: 1,
   countOffset: 0,
   dataMultiplier: 1,

--- a/test_data/common.js
+++ b/test_data/common.js
@@ -294,10 +294,11 @@ function mainTestLoop(options, defaultDB, isCluster, enterprise, fns, endOfLoopF
         db._useDatabase(database);
       }
       func(options,
-        isCluster,
-        enterprise,
-        database,
-        dbCount);
+           isCluster,
+           enterprise,
+           database,
+           dbCount,
+           options.readOnly);
     });
     let loopCount = options.collectionCountOffset;
     while (loopCount < options.collectionMultiplier) {
@@ -309,10 +310,11 @@ function mainTestLoop(options, defaultDB, isCluster, enterprise, fns, endOfLoopF
           db._useDatabase(database);
         }
         func(options,
-          isCluster,
-          enterprise,
-          dbCount,
-          loopCount);
+             isCluster,
+             enterprise,
+             dbCount,
+             loopCount,
+             options.readOnly);
       });
 
       progress('inner Loop End');

--- a/test_data/makedata.js
+++ b/test_data/makedata.js
@@ -80,6 +80,7 @@ const optionsDefaults = {
   curVersion: dbVersion,
   minReplicationFactor: 1,
   maxReplicationFactor: 2,
+  readOnly: false,
   numberOfDBs: 1,
   countOffset: 0,
   dataMultiplier: 1,

--- a/test_data/makedata_suites/070_foxx.js
+++ b/test_data/makedata_suites/070_foxx.js
@@ -190,7 +190,7 @@ const crudTestServiceSource = {
 
       let testKey = "test" + internal.md5(Date());
       reply = arango.POST_RAW(`/_db/${database}/crud_${dbCount}/xxx`, {_key: testKey});
-      if (options.readOnly) {
+      if (readOnly) {
         assertEqual(reply.code, "400", JSON.stringify(reply));
       } else {
         assertEqual(reply.code, "201", JSON.stringify(reply));
@@ -200,7 +200,7 @@ const crudTestServiceSource = {
       reply = arango.GET_RAW(`/_db/${database}/crud_${dbCount}/xxx`, onlyJson);
       assertEqual(reply.code, "200");
       parsedBody = JSON.parse(reply.body);
-      if (options.readOnly) {
+      if (readOnly) {
         assertEqual(parsedBody, [], JSON.stringify(reply));
       } else {
         assertEqual(parsedBody.length, 1, JSON.stringify(reply));
@@ -208,7 +208,7 @@ const crudTestServiceSource = {
 
       print(`${Date()} 070: Foxx: crud testing DELETE document`);
       reply = arango.DELETE_RAW(`/_db/${database}/crud_${dbCount}/xxx/${testKey}`);
-      if (options.readOnly) {
+      if (readOnly) {
         assertEqual(reply.code, "400", JSON.stringify(reply));
       } else {
         assertEqual(reply.code, "204", JSON.stringify(reply));

--- a/test_data/makedata_suites/071_foxx_utf-8.js
+++ b/test_data/makedata_suites/071_foxx_utf-8.js
@@ -107,7 +107,7 @@
       print(`${Date()} 071: Foxx: crud testing POST xxx`);
 
       reply = arango.POST_RAW(`/_db/${database}/crud_${dbCount}/xxx`, {_key: "test"});
-      if (options.readOnly) {
+      if (readOnly) {
         assertEqual(reply.code, "400", JSON.stringify(reply));
       } else {
         assertEqual(reply.code, "201", JSON.stringify(reply));
@@ -117,7 +117,7 @@
       reply = arango.GET_RAW(`/_db/${database}/crud_${dbCount}/xxx`, onlyJson);
       assertEqual(reply.code, "200", JSON.stringify(reply));
       parsedBody = JSON.parse(reply.body);
-      if (options.readOnly) {
+      if (readOnly) {
         assertEqual(parsedBody, []);
       } else {
         assertEqual(parsedBody.length, 1);
@@ -125,7 +125,7 @@
 
       print(`${Date()} 071: Foxx: crud testing delete document`);
       reply = arango.DELETE_RAW(`/_db/${database}/crud_${dbCount}/xxx/` + 'test');
-      if (options.readOnly) {
+      if (readOnly) {
         assertEqual(reply.code, "400", JSON.stringify(reply));
       } else {
         assertEqual(reply.code, "204", JSON.stringify(reply));


### PR DESCRIPTION
### Scope & Purpose

use a constant spelling of readOnly, and in tests use the arguments.

- [x] :hankey: Bugfix
